### PR TITLE
Splitting NitriteMapper into two interfaces #74

### DIFF
--- a/nitrite/src/main/java/org/dizitart/no2/mapper/NitriteMapper.java
+++ b/nitrite/src/main/java/org/dizitart/no2/mapper/NitriteMapper.java
@@ -73,19 +73,4 @@ public interface NitriteMapper {
      */
     Object asValue(Object object);
 
-    /**
-     * Parses a json string into a nitrite {@link Document}.
-     *
-     * @param json the json string to parse
-     * @return the document
-     */
-    Document parse(String json);
-
-    /**
-     * Serializes an object to a json string
-     *
-     * @param object the object
-     * @return the json string
-     */
-    String toJson(Object object);
 }

--- a/nitrite/src/main/java/org/dizitart/no2/tool/Exporter.java
+++ b/nitrite/src/main/java/org/dizitart/no2/tool/Exporter.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.exceptions.NitriteIOException;
-import org.dizitart.no2.mapper.JacksonMapper;
 
 import java.io.*;
 
@@ -60,7 +59,7 @@ public class Exporter {
         Exporter exporter = new Exporter();
         exporter.db = db;
 
-        ObjectMapper objectMapper = new JacksonMapper().getObjectMapper();
+        ObjectMapper objectMapper = new JacksonDeSerializer().getObjectMapper();
         exporter.jsonFactory = objectMapper.getFactory();
         exporter.options = new ExportOptions();
         return exporter;

--- a/nitrite/src/main/java/org/dizitart/no2/tool/Importer.java
+++ b/nitrite/src/main/java/org/dizitart/no2/tool/Importer.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dizitart.no2.Nitrite;
 import org.dizitart.no2.exceptions.NitriteIOException;
-import org.dizitart.no2.mapper.JacksonMapper;
 
 import java.io.*;
 
@@ -59,7 +58,7 @@ public class Importer {
     public static Importer of(Nitrite db) {
         Importer importer = new Importer();
         importer.db = db;
-        ObjectMapper objectMapper = new JacksonMapper().getObjectMapper();
+        ObjectMapper objectMapper = new JacksonDeSerializer().getObjectMapper();
         importer.jsonFactory = objectMapper.getFactory();
         return importer;
     }

--- a/nitrite/src/main/java/org/dizitart/no2/tool/JsonDeSerializer.java
+++ b/nitrite/src/main/java/org/dizitart/no2/tool/JsonDeSerializer.java
@@ -1,0 +1,11 @@
+package org.dizitart.no2.tool;
+
+import org.dizitart.no2.Document;
+
+public interface JsonDeSerializer {
+
+	Document parse(String json);
+
+	String toJson(Object object);
+
+}

--- a/nitrite/src/test/java/org/dizitart/no2/CollectionFindTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/CollectionFindTest.java
@@ -19,8 +19,8 @@
 package org.dizitart.no2;
 
 import org.dizitart.no2.filters.Filters;
-import org.dizitart.no2.mapper.JacksonMapper;
 import org.dizitart.no2.mapper.NitriteMapper;
+import org.dizitart.no2.tool.JacksonDeSerializer;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
@@ -412,7 +412,7 @@ public class CollectionFindTest extends BaseCollectionTest {
 
     @Test
     public void testElemMatchFilter() throws IOException {
-        NitriteMapper parser = new JacksonMapper();
+    	JacksonDeSerializer parser = new JacksonDeSerializer();
         Document doc1 = parser.parse("{ productScores: [ { product: \"abc\", score: 10 }, " +
                 "{ product: \"xyz\", score: 5 } ], strArray: [\"a\", \"b\"]}");
         Document doc2 = parser.parse("{ productScores: [ { product: \"abc\", score: 8 }, " +

--- a/nitrite/src/test/java/org/dizitart/no2/util/DocumentUtilsNegativeTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/util/DocumentUtilsNegativeTest.java
@@ -18,19 +18,19 @@
 
 package org.dizitart.no2.util;
 
-import org.dizitart.no2.Document;
-import org.dizitart.no2.exceptions.ValidationException;
-import org.dizitart.no2.mapper.JacksonMapper;
-import org.dizitart.no2.mapper.NitriteMapper;
-import org.junit.Before;
-import org.junit.Test;
+import static org.dizitart.no2.util.DocumentUtils.emptyDocument;
+import static org.dizitart.no2.util.DocumentUtils.getFieldValue;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.util.AbstractCollection;
 
-import static org.dizitart.no2.util.DocumentUtils.emptyDocument;
-import static org.dizitart.no2.util.DocumentUtils.getFieldValue;
-import static org.junit.Assert.assertEquals;
+import org.dizitart.no2.Document;
+import org.dizitart.no2.exceptions.ValidationException;
+import org.dizitart.no2.mapper.JacksonMapper;
+import org.dizitart.no2.tool.JacksonDeSerializer;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Anindya Chatterjee.
@@ -40,7 +40,7 @@ public class DocumentUtilsNegativeTest {
 
     @Before
     public void setUp() throws IOException {
-        NitriteMapper nitriteMapper = new JacksonMapper();
+    	JacksonDeSerializer nitriteMapper = new JacksonDeSerializer();
         doc = nitriteMapper.parse("{" +
                 "  score: 1034," +
                 "  location: {  " +

--- a/nitrite/src/test/java/org/dizitart/no2/util/DocumentUtilsTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/util/DocumentUtilsTest.java
@@ -19,8 +19,8 @@
 package org.dizitart.no2.util;
 
 import org.dizitart.no2.Document;
-import org.dizitart.no2.mapper.JacksonMapper;
 import org.dizitart.no2.mapper.NitriteMapper;
+import org.dizitart.no2.tool.JacksonDeSerializer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,7 +37,7 @@ public class DocumentUtilsTest {
 
     @Before
     public void setUp() throws IOException {
-        NitriteMapper nitriteMapper = new JacksonMapper();
+    	JacksonDeSerializer nitriteMapper = new JacksonDeSerializer();
         doc = nitriteMapper.parse("{" +
                 "  score: 1034," +
                 "  location: {  " +
@@ -56,7 +56,7 @@ public class DocumentUtilsTest {
 
     @Test
     public void testGetValue() throws IOException {
-        NitriteMapper nitriteMapper = new JacksonMapper();
+    	JacksonDeSerializer nitriteMapper = new JacksonDeSerializer();
         assertEquals(getFieldValue(doc, ""), null);
         assertEquals(getFieldValue(doc, "score"), 1034);
         assertEquals(getFieldValue(doc, "location.state"), "NY");

--- a/nitrite/src/test/java/org/dizitart/no2/util/ObjectUtilsNegativeTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/util/ObjectUtilsNegativeTest.java
@@ -18,19 +18,19 @@
 
 package org.dizitart.no2.util;
 
+import static org.dizitart.no2.util.ObjectUtils.extractIndices;
+import static org.dizitart.no2.util.ObjectUtils.findObjectStoreName;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Iterator;
+import java.util.Set;
+
 import org.dizitart.no2.exceptions.IndexingException;
 import org.dizitart.no2.exceptions.ValidationException;
 import org.dizitart.no2.mapper.JacksonMapper;
 import org.dizitart.no2.mapper.NitriteMapper;
 import org.dizitart.no2.objects.Index;
 import org.junit.Test;
-
-import java.util.Iterator;
-import java.util.Set;
-
-import static org.dizitart.no2.util.ObjectUtils.extractIndices;
-import static org.dizitart.no2.util.ObjectUtils.findObjectStoreName;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Anindya Chatterjee.

--- a/nitrite/src/test/java/org/dizitart/no2/util/ObjectUtilsTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/util/ObjectUtilsTest.java
@@ -18,17 +18,20 @@
 
 package org.dizitart.no2.util;
 
+import static org.dizitart.no2.util.ObjectUtils.extractIndices;
+import static org.dizitart.no2.util.ObjectUtils.findObjectStoreName;
+import static org.dizitart.no2.util.ObjectUtils.isObjectStore;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
 import org.dizitart.no2.mapper.JacksonMapper;
 import org.dizitart.no2.mapper.NitriteMapper;
 import org.dizitart.no2.objects.Index;
 import org.dizitart.no2.objects.Indices;
 import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.util.Set;
-
-import static org.dizitart.no2.util.ObjectUtils.*;
-import static org.junit.Assert.*;
 
 /**
  * @author Anindya Chatterjee.

--- a/nitrite/src/test/java/org/dizitart/no2/util/ValidationUtilsTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/util/ValidationUtilsTest.java
@@ -18,20 +18,28 @@
 
 package org.dizitart.no2.util;
 
+import static org.dizitart.no2.Constants.INDEX_META_PREFIX;
+import static org.dizitart.no2.Constants.INDEX_PREFIX;
+import static org.dizitart.no2.Constants.INTERNAL_NAME_SEPARATOR;
+import static org.dizitart.no2.Constants.OBJECT_STORE_NAME_SEPARATOR;
+import static org.dizitart.no2.Constants.USER_MAP;
+import static org.dizitart.no2.exceptions.ErrorMessage.errorMessage;
+import static org.dizitart.no2.util.ValidationUtils.notEmpty;
+import static org.dizitart.no2.util.ValidationUtils.notNull;
+import static org.dizitart.no2.util.ValidationUtils.validateCollectionName;
+import static org.dizitart.no2.util.ValidationUtils.validateLimit;
+import static org.dizitart.no2.util.ValidationUtils.validateObjectIndexField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 import org.dizitart.no2.FindOptions;
 import org.dizitart.no2.exceptions.IndexingException;
 import org.dizitart.no2.exceptions.ValidationException;
 import org.dizitart.no2.mapper.JacksonMapper;
 import org.dizitart.no2.mapper.NitriteMapper;
 import org.junit.Test;
-
-import java.util.List;
-
-import static org.dizitart.no2.Constants.*;
-import static org.dizitart.no2.exceptions.ErrorMessage.errorMessage;
-import static org.dizitart.no2.util.ValidationUtils.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Anindya Chatterjee.


### PR DESCRIPTION
I split `NitriteMapper` and `JacksonMapper` each into two classes/interfaces.

The `parse/toJson` methods are in the new Interface/Class `JsonDeSerializer` and `JacksonDeSerialzer` (feel free to move and rename them).

Some tests had to be adjusted. Unfortunately not all tests are running green on my windows machine (there seems to be an issue with the file system), yet the changes did not change test results, so I am confident that this refactoring works.