### PR TITLE
Microoptimize

### DIFF
--- a/nitrite/src/main/java/org/dizitart/no2/filters/ElementMatchFilter.java
+++ b/nitrite/src/main/java/org/dizitart/no2/filters/ElementMatchFilter.java
@@ -73,7 +73,7 @@ class ElementMatchFilter extends BaseFilter {
 
             if (fieldValue.getClass().isArray()) {
                 int length = Array.getLength(fieldValue);
-                List list = new ArrayList();
+                List list = new ArrayList(length);
                 for (int i = 0; i < length; i++) {
                     Object item = Array.get(fieldValue, i);
                     list.add(item);

--- a/nitrite/src/main/java/org/dizitart/no2/internals/DefaultNitriteCollection.java
+++ b/nitrite/src/main/java/org/dizitart/no2/internals/DefaultNitriteCollection.java
@@ -50,8 +50,8 @@ class DefaultNitriteCollection implements NitriteCollection {
     private NitriteService nitriteService;
     private volatile boolean isDropped;
     private EventBus<ChangeInfo, ChangeListener> eventBus;
-    private String collectionName;
-    private NitriteContext nitriteContext;
+    private final String collectionName;
+    private final NitriteContext nitriteContext;
 
     DefaultNitriteCollection(NitriteMap<NitriteId, Document> nitriteMap, NitriteContext nitriteContext) {
         this.nitriteMap = nitriteMap;

--- a/nitrite/src/main/java/org/dizitart/no2/store/NitriteMVMap.java
+++ b/nitrite/src/main/java/org/dizitart/no2/store/NitriteMVMap.java
@@ -33,8 +33,8 @@ import static org.dizitart.no2.util.StringUtils.isNullOrEmpty;
  * @author Anindya Chatterjee.
  */
 class NitriteMVMap<Key, Value> implements NitriteMap<Key, Value> {
-    private MVMap<Key, Value> mvMap;
-    private NitriteStore nitriteStore;
+    private final MVMap<Key, Value> mvMap;
+    private final NitriteStore nitriteStore;
 
     NitriteMVMap(MVMap<Key, Value> mvMap, NitriteStore nitriteStore) {
         this.mvMap = mvMap;

--- a/nitrite/src/main/java/org/dizitart/no2/store/NitriteMVStore.java
+++ b/nitrite/src/main/java/org/dizitart/no2/store/NitriteMVStore.java
@@ -33,7 +33,7 @@ import static org.dizitart.no2.Constants.META_MAP_NAME;
  * @author Anindya Chatterjee.
  */
 public final class NitriteMVStore implements NitriteStore {
-    private MVStore mvStore;
+    private final MVStore mvStore;
 
     /**
      * Instantiates a new {@link NitriteMVStore}.

--- a/nitrite/src/main/java/org/dizitart/no2/tool/Importer.java
+++ b/nitrite/src/main/java/org/dizitart/no2/tool/Importer.java
@@ -80,8 +80,9 @@ public class Importer {
      * @throws NitriteIOException  if there is any low-level I/O error.
      */
     public void importFrom(File file) {
-        try {
-            importFrom(new FileInputStream(file));
+
+        try(FileInputStream stream = new FileInputStream(file);) {
+            importFrom(stream);
         } catch (IOException ioe) {
             throw new NitriteIOException(
                     errorMessage("I/O error while reading content from file " + file,

--- a/nitrite/src/test/java/org/dizitart/no2/tool/ExporterImporterTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/tool/ExporterImporterTest.java
@@ -40,7 +40,7 @@ public class ExporterImporterTest extends BaseExternalTest {
     @Test
     public void testImportExport() {
         schemaFile = System.getProperty("java.io.tmpdir") + File.separator
-                + "nitrite" + File.separator + "schema.json";
+                + "nitriteEIT" + File.separator + "schema.json";
 
         Random random = new Random();
         for (int i = 0; i < 5; i++) {

--- a/nitrite/src/test/java/org/dizitart/no2/tool/ExporterImporterTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/tool/ExporterImporterTest.java
@@ -40,7 +40,7 @@ public class ExporterImporterTest extends BaseExternalTest {
     @Test
     public void testImportExport() {
         schemaFile = System.getProperty("java.io.tmpdir") + File.separator
-                + "nitriteEIT" + File.separator + "schema.json";
+                + "nitrite" + File.separator + "schemaEIT.json";
 
         Random random = new Random();
         for (int i = 0; i < 5; i++) {

--- a/nitrite/src/test/java/org/dizitart/no2/tool/ExporterImporterTest.java
+++ b/nitrite/src/test/java/org/dizitart/no2/tool/ExporterImporterTest.java
@@ -40,7 +40,7 @@ public class ExporterImporterTest extends BaseExternalTest {
     @Test
     public void testImportExport() {
         schemaFile = System.getProperty("java.io.tmpdir") + File.separator
-                + "nitrite" + File.separator + "schemaEIT.json";
+                + "nitrite" + File.separator + "schema.json";
 
         Random random = new Random();
         for (int i = 0; i < 5; i++) {

--- a/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/ImportExportTest.kt
+++ b/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/ImportExportTest.kt
@@ -38,7 +38,7 @@ class ImportExportTest : BaseExternalTest() {
     @Test
     fun testImportExport() {
         schemaFile = (System.getProperty("java.io.tmpdir") + File.separator
-            + "kno" + File.separator + "schema.json")
+            + "kno2" + File.separator + "schema.json")
 
         val random = Random()
         for (i in 0..4) {

--- a/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/ImportExportTest.kt
+++ b/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/ImportExportTest.kt
@@ -38,7 +38,7 @@ class ImportExportTest : BaseExternalTest() {
     @Test
     fun testImportExport() {
         schemaFile = (System.getProperty("java.io.tmpdir") + File.separator
-            + "nitrite" + File.separator + "schema.json")
+            + "nitriteIET" + File.separator + "schema.json")
 
         val random = Random()
         for (i in 0..4) {

--- a/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/ImportExportTest.kt
+++ b/potassium-nitrite/src/test/kotlin/org/dizitart/kno2/ImportExportTest.kt
@@ -38,7 +38,7 @@ class ImportExportTest : BaseExternalTest() {
     @Test
     fun testImportExport() {
         schemaFile = (System.getProperty("java.io.tmpdir") + File.separator
-            + "nitriteIET" + File.separator + "schema.json")
+            + "kno" + File.separator + "schema.json")
 
         val random = Random()
         for (i in 0..4) {


### PR DESCRIPTION
Microoptimizations in DataService  …
1) Use Slf4j in recommended way - pass parameters instead of string concatenation
This reduces allocations when logging is not enabled
2) Preallocate array lists when exact size in know
This also reduces allocations and memory footprint

Also this PR fixes unclosed stream in importer